### PR TITLE
Jpab 14 - PostService 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/be/app/common/dto/ApiResponse.java
+++ b/src/main/java/com/prgrms/be/app/common/dto/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;

--- a/src/main/java/com/prgrms/be/app/common/dto/PageRequest.java
+++ b/src/main/java/com/prgrms/be/app/common/dto/PageRequest.java
@@ -1,37 +1,37 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.common.dto;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+
+import static org.springframework.data.domain.Sort.Direction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostPageRequest {
+public class PageRequest {
 
     private static final int DEFAULT_SIZE = 10;
     private static final int MAX_SIZE = 20;
 
     private int page;
     private int size;
-    private Sort.Direction direction;
+    private Direction direction;
 
-    public PostPageRequest(int page, int size, Sort.Direction direction) {
+    public PageRequest(int page, int size) {
+        this(page, size, Direction.DESC);
+    }
+
+    public PageRequest(int page, int size, Direction direction) {
         this.page = page <= 0 ? 1 : page;
         this.size = isRangeSize(size) ? size : DEFAULT_SIZE;
         this.direction = direction;
-    }
-
-    public PostPageRequest(int page, int size) {
-        this(page, size, Sort.Direction.DESC);
     }
 
     private boolean isRangeSize(int size) {
         return size > 0 && size <= MAX_SIZE;
     }
 
-    public PageRequest of() {
-        return PageRequest.of(page - 1, size, direction, "createdAt");
+    public org.springframework.data.domain.PageRequest of() {
+        return org.springframework.data.domain.PageRequest.of(page - 1, size, direction, "createdAt");
     }
 }

--- a/src/main/java/com/prgrms/be/app/common/dto/ResponseMessage.java
+++ b/src/main/java/com/prgrms/be/app/common/dto/ResponseMessage.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.controller;
+package com.prgrms.be.app.common.dto;
 
 public class ResponseMessage {
     public static final String CREATED = "게시물 생성 완료";

--- a/src/main/java/com/prgrms/be/app/common/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/prgrms/be/app/common/exception/ControllerExceptionHandler.java
@@ -1,6 +1,7 @@
-package com.prgrms.be.app.controller;
+package com.prgrms.be.app.common.exception;
 
-import com.prgrms.be.app.domain.dto.ApiResponse;
+import com.prgrms.be.app.common.dto.ApiResponse;
+import com.prgrms.be.app.common.dto.ResponseMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/prgrms/be/app/domain/config/BaseEntity.java
+++ b/src/main/java/com/prgrms/be/app/domain/config/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.domain;
+package com.prgrms.be.app.domain.config;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/prgrms/be/app/domain/config/JpaConfig.java
+++ b/src/main/java/com/prgrms/be/app/domain/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.config;
+package com.prgrms.be.app.domain.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/prgrms/be/app/domain/post/Post.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/Post.java
@@ -1,5 +1,7 @@
-package com.prgrms.be.app.domain;
+package com.prgrms.be.app.domain.post;
 
+import com.prgrms.be.app.domain.config.BaseEntity;
+import com.prgrms.be.app.domain.user.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -63,11 +65,11 @@ public class Post extends BaseEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Post post = (Post) o;
-        return Objects.equals(id, post.id) && Objects.equals(title, post.title) && Objects.equals(content, post.content) && Objects.equals(createdBy, post.createdBy);
+        return id.equals(post.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, title, content, createdBy);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/prgrms/be/app/domain/post/controller/PostController.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/controller/PostController.java
@@ -1,7 +1,13 @@
-package com.prgrms.be.app.controller;
+package com.prgrms.be.app.domain.post.controller;
 
-import com.prgrms.be.app.domain.dto.*;
-import com.prgrms.be.app.service.PostService;
+import com.prgrms.be.app.common.dto.ApiResponse;
+import com.prgrms.be.app.common.dto.PageRequest;
+import com.prgrms.be.app.common.dto.ResponseMessage;
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostDetailResponse;
+import com.prgrms.be.app.domain.post.dto.PostUpdateRequest;
+import com.prgrms.be.app.domain.post.dto.PostsResponse;
+import com.prgrms.be.app.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,8 +38,8 @@ public class PostController {
     }
 
     @GetMapping
-    public ApiResponse<PostsResponse> getAll(@RequestBody PostPageRequest postPageRequest) {
-        PostsResponse postPages = postService.findAll(postPageRequest.of());
+    public ApiResponse<PostsResponse> getAll(@RequestBody PageRequest pageRequest) {
+        PostsResponse postPages = postService.findAll(pageRequest.of());
         return ApiResponse.ok(
                 postPages,
                 ResponseMessage.FINDED_ALL

--- a/src/main/java/com/prgrms/be/app/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/dto/PostCreateRequest.java
@@ -1,20 +1,24 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.domain.post.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.persistence.Column;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Getter
 @AllArgsConstructor
-public class PostUpdateRequest {
-    @NotBlank(message = "게시글의 제목을 빈 상태로 수정할 수 없습니다.")
+public class PostCreateRequest {
+    @NotBlank(message = "게시글의 제목을 기입해야 합니다.")
     @Size(min = 1, max = 20)
     private String title;
 
-    @NotBlank(message = "게시글의 내용을 빈 상태로 수정할 수 없습니다.")
+    @NotBlank(message = "게시글의 내용을 기입해야 합니다.")
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @NotNull
+    private Long userId;
 }

--- a/src/main/java/com/prgrms/be/app/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/dto/PostDetailResponse.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.domain.post.dto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/prgrms/be/app/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/dto/PostUpdateRequest.java
@@ -1,24 +1,20 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.domain.post.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.persistence.Column;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Getter
 @AllArgsConstructor
-public class PostCreateRequest {
-    @NotBlank(message = "게시글의 제목을 기입해야 합니다.")
+public class PostUpdateRequest {
+    @NotBlank(message = "게시글의 제목을 빈 상태로 수정할 수 없습니다.")
     @Size(min = 1, max = 20)
     private String title;
 
-    @NotBlank(message = "게시글의 내용을 기입해야 합니다.")
+    @NotBlank(message = "게시글의 내용을 빈 상태로 수정할 수 없습니다.")
     @Column(columnDefinition = "TEXT")
     private String content;
-
-    @NotNull
-    private Long userId;
 }

--- a/src/main/java/com/prgrms/be/app/domain/post/dto/PostsResponse.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/dto/PostsResponse.java
@@ -1,4 +1,4 @@
-package com.prgrms.be.app.domain.dto;
+package com.prgrms.be.app.domain.post.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/prgrms/be/app/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/repository/PostRepository.java
@@ -1,6 +1,6 @@
-package com.prgrms.be.app.repository;
+package com.prgrms.be.app.domain.post.repository;
 
-import com.prgrms.be.app.domain.Post;
+import com.prgrms.be.app.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {

--- a/src/main/java/com/prgrms/be/app/domain/post/service/PostService.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/service/PostService.java
@@ -1,13 +1,13 @@
-package com.prgrms.be.app.service;
+package com.prgrms.be.app.domain.post.service;
 
-import com.prgrms.be.app.domain.Post;
-import com.prgrms.be.app.domain.User;
-import com.prgrms.be.app.domain.dto.PostCreateRequest;
-import com.prgrms.be.app.domain.dto.PostDetailResponse;
-import com.prgrms.be.app.domain.dto.PostUpdateRequest;
-import com.prgrms.be.app.domain.dto.PostsResponse;
-import com.prgrms.be.app.repository.PostRepository;
-import com.prgrms.be.app.repository.UserRepository;
+import com.prgrms.be.app.domain.post.Post;
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostDetailResponse;
+import com.prgrms.be.app.domain.post.dto.PostUpdateRequest;
+import com.prgrms.be.app.domain.post.dto.PostsResponse;
+import com.prgrms.be.app.domain.post.repository.PostRepository;
+import com.prgrms.be.app.domain.user.User;
+import com.prgrms.be.app.domain.user.repository.UserRepository;
 import com.prgrms.be.app.util.PostConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,8 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 
-
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class PostService {
 
@@ -26,13 +26,11 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostConverter postConverter;
 
-    @Transactional(readOnly = true)
     public PostsResponse findAll(Pageable pageable) {
         Page<Post> all = postRepository.findAll(pageable);
         return postConverter.convertToPostsResponse(all);
     }
 
-    @Transactional(readOnly = true)
     public PostDetailResponse findById(Long id) {
         return postRepository.findById(id)
                 .map(postConverter::convertToPostDetailResponse)

--- a/src/main/java/com/prgrms/be/app/domain/user/User.java
+++ b/src/main/java/com/prgrms/be/app/domain/user/User.java
@@ -1,5 +1,7 @@
-package com.prgrms.be.app.domain;
+package com.prgrms.be.app.domain.user;
 
+import com.prgrms.be.app.domain.config.BaseEntity;
+import com.prgrms.be.app.domain.post.Post;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/prgrms/be/app/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/be/app/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.prgrms.be.app.repository;
+package com.prgrms.be.app.domain.user.repository;
 
-import com.prgrms.be.app.domain.User;
+import com.prgrms.be.app.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/src/main/java/com/prgrms/be/app/util/PostConverter.java
+++ b/src/main/java/com/prgrms/be/app/util/PostConverter.java
@@ -1,10 +1,10 @@
 package com.prgrms.be.app.util;
 
-import com.prgrms.be.app.domain.Post;
-import com.prgrms.be.app.domain.User;
-import com.prgrms.be.app.domain.dto.PostCreateRequest;
-import com.prgrms.be.app.domain.dto.PostDetailResponse;
-import com.prgrms.be.app.domain.dto.PostsResponse;
+import com.prgrms.be.app.domain.post.Post;
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostDetailResponse;
+import com.prgrms.be.app.domain.post.dto.PostsResponse;
+import com.prgrms.be.app.domain.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 

--- a/src/test/java/com/prgrms/be/app/controller/PostControllerTest.java
+++ b/src/test/java/com/prgrms/be/app/controller/PostControllerTest.java
@@ -1,8 +1,13 @@
 package com.prgrms.be.app.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.be.app.domain.dto.*;
-import com.prgrms.be.app.service.PostService;
+import com.prgrms.be.app.common.dto.PageRequest;
+import com.prgrms.be.app.common.dto.ResponseMessage;
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostDetailResponse;
+import com.prgrms.be.app.domain.post.dto.PostUpdateRequest;
+import com.prgrms.be.app.domain.post.dto.PostsResponse;
+import com.prgrms.be.app.domain.post.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
@@ -183,8 +187,8 @@ class PostControllerTest {
     @DisplayName("현재 페이지 정보와 한 페이지 당 게시글 수를 입력 시 페이징된 게시글이 반환되며 게시글의 정보는 게시글 ID, 제목, 생성일자가 반환된다.")
     void getAllCallTest() throws Exception {
         // given
-        PostPageRequest postPageRequest = new PostPageRequest(0, 5, Sort.Direction.DESC);
-        Pageable request = PageRequest.of(0, 5);
+        PageRequest pageRequest = new PageRequest(0, 5, Sort.Direction.DESC);
+        Pageable request = org.springframework.data.domain.PageRequest.of(0, 5);
         List<PostDetailResponse> postDtos = List.of(
                 new PostDetailResponse("title1", "content1", 1L, LocalDateTime.now(), 1L, "user1"),
                 new PostDetailResponse("title2", "content2", 2L, LocalDateTime.now(), 2L, "user2"),
@@ -196,7 +200,7 @@ class PostControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/posts")
-                        .content(objectMapper.writeValueAsString(postPageRequest))
+                        .content(objectMapper.writeValueAsString(pageRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print());

--- a/src/test/java/com/prgrms/be/app/domain/PostTest.java
+++ b/src/test/java/com/prgrms/be/app/domain/PostTest.java
@@ -1,5 +1,7 @@
 package com.prgrms.be.app.domain;
 
+import com.prgrms.be.app.domain.post.Post;
+import com.prgrms.be.app.domain.user.User;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/prgrms/be/app/domain/UserTest.java
+++ b/src/test/java/com/prgrms/be/app/domain/UserTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.be.app.domain;
 
+import com.prgrms.be.app.domain.user.User;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/prgrms/be/app/domain/dto/PostDTOTest.java
+++ b/src/test/java/com/prgrms/be/app/domain/dto/PostDTOTest.java
@@ -1,5 +1,7 @@
 package com.prgrms.be.app.domain.dto;
 
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostUpdateRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/prgrms/be/app/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/be/app/service/PostServiceTest.java
@@ -1,13 +1,14 @@
 package com.prgrms.be.app.service;
 
-import com.prgrms.be.app.domain.Post;
-import com.prgrms.be.app.domain.User;
-import com.prgrms.be.app.domain.dto.PostCreateRequest;
-import com.prgrms.be.app.domain.dto.PostDetailResponse;
-import com.prgrms.be.app.domain.dto.PostUpdateRequest;
-import com.prgrms.be.app.domain.dto.PostsResponse;
-import com.prgrms.be.app.repository.PostRepository;
-import com.prgrms.be.app.repository.UserRepository;
+import com.prgrms.be.app.domain.post.Post;
+import com.prgrms.be.app.domain.post.dto.PostCreateRequest;
+import com.prgrms.be.app.domain.post.dto.PostDetailResponse;
+import com.prgrms.be.app.domain.post.dto.PostUpdateRequest;
+import com.prgrms.be.app.domain.post.dto.PostsResponse;
+import com.prgrms.be.app.domain.post.repository.PostRepository;
+import com.prgrms.be.app.domain.post.service.PostService;
+import com.prgrms.be.app.domain.user.User;
+import com.prgrms.be.app.domain.user.repository.UserRepository;
 import com.prgrms.be.app.util.PostConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
# 수정한 사항
- 패키지 구조 변경.
- @Transactional 위치 변경을 통한 중복 코드 제거.

# 추가 고민한 사항
- PostService에서 사용되는 PostConverter라는 assembler 클래스를 없애고 DTO 안에 toEntity 라는 메소드와 같은 변환 로직을 담을까 고민. -> 기능이 많아질수록 DTO가 늘어나고 변환 클래스도 커질 것이라 생각.
- 이에 대한 명확한 답변이 없어서 chat gpt 이용
  - assembler 클래스를 이용하면 변환 로직들을 한 곳에서 관리할 수 있어 문제를 명확하게 분리하고 코드 유지 및 관리 그리고 이해가 더 용이해짐.
  - DTO 내부 메소드로 포함 시키는 경우 DTO에서 직접 로직에 엑세스할 수 있어 코드가 단순해지고 사용하기에 용이해짐.
- 결론 : 배움을 위한 프로젝트이기에 assembler 클래스를 이용하면서 코드의 유지 보수에 더 신경을 쓰기로 결정하여 원래 로직을 그대로 유지.