### PR TITLE
Jpab 8 - post validation 추가

### DIFF
--- a/src/main/java/com/prgrms/be/app/domain/post/Post.java
+++ b/src/main/java/com/prgrms/be/app/domain/post/Post.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class Post extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull


### PR DESCRIPTION
- post entity에 마땅히 추가할 validation이 없었음.
- 대리키 생성 전략 명시